### PR TITLE
HTML Javadoc

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -31,8 +31,8 @@ import net.htmlparser.jericho.Source;
 import net.htmlparser.jericho.TextExtractor;
 
 /**
- * Represents HTML content, providing the ability to escape, render, replace,
- * and strip HTML text. This class uses XSS recommendations from <a
+ * Provides the implementation for escaping, rendering, replacing, and stripping
+ * HTML text. This class uses XSS recommendations from <a
  * href="http://www.owasp.org/index.php/Cross_Site_Scripting#How_to_Protect_Yourself">http://www.owasp.org/index.php/Cross_Site_Scripting#How_to_Protect_Yourself</a>
  * when escaping HTML text.
  *
@@ -155,7 +155,7 @@ public class HtmlImpl implements Html {
 	}
 
 	/**
-	 * Escapes the input text as a hexadecimal value, based on the type (mode).
+	 * Escapes the input text as a hexadecimal value, based on the mode (type).
 	 * The encoding types include: {@link #ESCAPE_MODE_ATTRIBUTE}, {@link
 	 * #ESCAPE_MODE_CSS}, {@link #ESCAPE_MODE_JS}, {@link #ESCAPE_MODE_TEXT},
 	 * and {@link #ESCAPE_MODE_URL}.
@@ -166,9 +166,9 @@ public class HtmlImpl implements Html {
 	 * </p>
 	 *
 	 * @param  text the text to escape
-	 * @param  type the encoding type
+	 * @param  mode the encoding type
 	 * @return the escaped hexadecimal value of the input text, based on the
-	 *         type, or <code>null</code> if the text is <code>null</code>
+	 *         mode, or <code>null</code> if the text is <code>null</code>
 	 */
 	@Override
 	public String escape(String text, int mode) {
@@ -440,7 +440,7 @@ public class HtmlImpl implements Html {
 	 * Replaces all new lines or carriage returns with the <code><br /></code>
 	 * HTML tag.
 	 *
-	 * @param  text the text
+	 * @param  html the text
 	 * @return the converted text, or <code>null</code> if the text is
 	 *         <code>null</code>
 	 */

--- a/portal-service/src/com/liferay/portal/kernel/util/HtmlUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/HtmlUtil.java
@@ -32,7 +32,7 @@ public class HtmlUtil {
 	/**
 	 * Escapes the text so that it is safe to use in an HTML context.
 	 *
-	 * @param  html the text to escape
+	 * @param  text the text to escape
 	 * @return the escaped HTML text, or <code>null</code> if the text is
 	 *         <code>null</code>
 	 */
@@ -43,7 +43,7 @@ public class HtmlUtil {
 	/**
 	 * Escapes the input text as a hexadecimal value, based on the mode (type).
 	 *
-	 * @param  html the text to escape
+	 * @param  text the text to escape
 	 * @param  mode the encoding type
 	 * @return the escaped hexadecimal value of the input text, based on the
 	 *         mode, or <code>null</code> if the text is <code>null</code>
@@ -170,7 +170,7 @@ public class HtmlUtil {
 	 * Replaces all Microsoft Word Unicode characters with plain HTML entities
 	 * or characters.
 	 *
-	 * @param  html the text
+	 * @param  text the text
 	 * @return the converted text, or <code>null</code> if the text is
 	 *         <code>null</code>
 	 */
@@ -200,7 +200,7 @@ public class HtmlUtil {
 	 * Self-closing tags remain in the result.
 	 * </p>
 	 *
-	 * @param  html the text
+	 * @param  text the text
 	 * @param  tag the tag used for delimiting, which should only be the tag's
 	 *         name (e.g. no &lt;)
 	 * @return the text, without the stripped tag and its contents, or
@@ -213,7 +213,7 @@ public class HtmlUtil {
 	/**
 	 * Strips all XML comments out of the text.
 	 *
-	 * @param  html the text
+	 * @param  text the text
 	 * @return the text, without the stripped XML comments, or <code>null</code>
 	 *         if the text is <code>null</code>
 	 */
@@ -233,7 +233,7 @@ public class HtmlUtil {
 	 * <code>&amp;amp;</code>.
 	 * </p>
 	 *
-	 * @param  html the text
+	 * @param  text the text
 	 * @return the encoded text that is safe to use as an HTML input field
 	 *         value, or <code>null</code> if the text is <code>null</code>
 	 */


### PR DESCRIPTION
Hey Jim,

Notice that I had to update a param from `text` -> `html` in the `HtmlImpl` class. We had discussed how the `Html` class was the example to follow for variable names, but that most changes were needed in the `HtmlUtil` class.

Now all variable names are synced with the `Html` interface, and all Javadoc reflects these changes.

https://issues.liferay.com/browse/LRDOCS-939
